### PR TITLE
Bump commons-io

### DIFF
--- a/others/code/springboot-kubernetes/02-usermanagement-service/pom.xml
+++ b/others/code/springboot-kubernetes/02-usermanagement-service/pom.xml
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.5</version>
+			<version>2.7</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Bumps commons-io from 2.5 to 2.7.

Signed-off-by: dependabot[bot] <support@github.com>